### PR TITLE
Updating XMLParser iterator syntax to 'next(self.context)' instead of…

### DIFF
--- a/jtl.py
+++ b/jtl.py
@@ -107,7 +107,7 @@ class XMLParser(BaseParser):
         """
         self.context = etree.iterparse(source, events=('start', 'end'))
         self.context = iter(self.context)
-        event, self.root = self.context.next()
+	event, self.root = next(self.context)
         self.version = self.root.get('version')
 
     def _get_assertion_results(self, elem):


### PR DESCRIPTION
… 'self.context.next() for python3 compatibility'

I've been using this library to do a lot of jtl parsing, but this update was necessary to parse XML files using python3. Hoping to keep this repo current as I know a couple more people who will probably use it. 